### PR TITLE
change task name. 'sass' -> 'build-sass'

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -60,7 +60,7 @@ gulp.task('zip', function() {
 
 gulp.task('watch', () => {
     gulp.watch('./src/templates/*.hbs', ['build-templates']);
-    gulp.watch('./src/sass/**/*.scss', ['sass']);
+    gulp.watch('./src/sass/**/*.scss', ['build-sass']);
     gulp.watch('./src/js/**', ['build-js'])
 });
 


### PR DESCRIPTION
can't found 'sass' task in 'watch'. so I do changed 'watch' target name.